### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,9 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -188,3 +188,4 @@
   <span class='purchase-btn-text'>出品する</span>
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
 <% end %>
+<%= render "shared/footer" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
       <% if @items.length != 0 %>
       <li class='list'>
         <% @items.each do |item| %>
-            <%= link_to "#" do %>
+            <%= link_to item_path(item.id) do %>
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -146,7 +146,7 @@
                 <%= "#{item.name}" %>
               </h3>
               <div class='item-price'>
-                <span><%= "#{item.price.to_s(:delimited)}" %>円<br><%= '配送料負担' %></span>
+                <span><%= "#{item.price.to_s(:delimited)}" %>円<br><%= "#{item.delivery_fee.name}" %></span>
                 <div class='star-btn'>
                   <%= image_tag "star.png", class:"star-icon" %>
                   <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -146,7 +146,7 @@
                 <%= "#{item.name}" %>
               </h3>
               <div class='item-price'>
-                <span><%= "#{item.price}" %>円<br><%= '配送料負担' %></span>
+                <span><%= "#{item.price.to_s(:delimited)}" %>円<br><%= '配送料負担' %></span>
                 <div class='star-btn'>
                   <%= image_tag "star.png", class:"star-icon" %>
                   <span class='star-count'>0</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= "#{@item.name}" %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -19,7 +19,7 @@
         ¥ 999,999,999
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= "#{@item.delivery_fee.name}" %>
       </span>
     </div>
 
@@ -43,27 +43,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= "#{@item.user.name}" %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= "#{@item.explanation_category.name}" %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= "#{@item.explanation_condition.name}" %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= "#{@item.delivery_fee.name}" %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= "#{@item.shipment_source_address.name}" %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= "#{@item.shipment_day.name}" %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= "¥#{@item.price.to_s(:delimited)}" %>
       </span>
       <span class="item-postage">
         <%= "#{@item.delivery_fee.name}" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -38,7 +38,7 @@
     <% else %>
     <% end %>
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= "#{@item.explanation}" %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,18 +24,19 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? && current_user.id == @item.user.id %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% elsif user_signed_in? && current_user.id != @item.user.id%>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
-
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% else %>
+    <% end %>
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
     </div>
@@ -103,7 +104,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href=“#” class=‘another-item’><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href=“#” class=‘another-item’><%= "#{@item.explanation_category.name}" %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 


### PR DESCRIPTION
#what 
商品詳細表示機能の実装
# why
商品詳細表示機能の実装のため

[未ログイン状態のユーザの詳細表示画面への遷移](https://gyazo.com/e29c4c93efd114b96c304e91b26e8fd2)
[ログインユーザーが自分の出品商品の詳細表示画面への遷移](https://gyazo.com/a4996a1a70844e74e12849d3c963ef62)
[ログインユーザーが他の出品者の詳細表示画面への遷移](https://gyazo.com/b611f4a5d32176f4d6239ea880a729dc)